### PR TITLE
Make focus on layout optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Works on both iOS and Android.
 	iOSPadding | boolean | `true` | Pad the size of the iOS status bar
 	clearOnShow | boolean | `false` | Clear input when the search bar is shown
 	clearOnHide | boolean | `true` | Clear input when the search bar is hidden
-  focusOnLayout | boolean | `true` | Focus the text input box whenever it is shown 
+	focusOnLayout | boolean | `true` | Focus the text input box whenever it is shown 
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Works on both iOS and Android.
 	iOSPadding | boolean | `true` | Pad the size of the iOS status bar
 	clearOnShow | boolean | `false` | Clear input when the search bar is shown
 	clearOnHide | boolean | `true` | Clear input when the search bar is hidden
+  focusOnLayout | boolean | `true` | Focus the text input box whenever it is shown 
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ export default class Search extends Component {
     iOSPadding: PropTypes.bool,
     clearOnShow: PropTypes.bool,
     clearOnHide: PropTypes.bool,
+    focusOnLayout: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -55,6 +56,7 @@ export default class Search extends Component {
     iOSPadding: true,
     clearOnShow: false,
     clearOnHide: true,
+    focusOnLayout: true,
   }
 
   constructor(props) {
@@ -182,7 +184,7 @@ export default class Search extends Component {
               }
               <TextInput
                 ref={(ref) => this.textInput = ref}
-                onLayout={() => this.textInput.focus()}
+                onLayout={() => this.props.focusOnLayout && this.textInput.focus()}
                 style={[
                   styles.input,
                   {


### PR DESCRIPTION
In my current project, we decided to use your neat search bar implementation here. Unfortunately, our use case is apparently slightly different to yours: we have the search input box always visible on the screen, rather than showing it only when the user taps a search button or something. With the current version of react-native-searchbar, the onLayout event of the text input box unconditionally triggers a focus. This obviously brings up the keyboard. So in our app, whenever the user navigates to a screen which has a search box, the keyboard pops up regardless of whether the user wants to do a search.

In this PR, I have just added an option to disable the focus-on-layout behaviour. It maintains the old behaviour by default so should be backwards compatible with previous versions.