### PR TITLE
added autoCorrect prop to TextInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Works on both iOS and Android.
 	iOSPadding | boolean | `true` | Pad the size of the iOS status bar
 	clearOnShow | boolean | `false` | Clear input when the search bar is shown
 	clearOnHide | boolean | `true` | Clear input when the search bar is hidden
-	focusOnLayout | boolean | `true` | Focus the text input box whenever it is shown 
+	focusOnLayout | boolean | `true` | Focus the text input box whenever it is shown
+	autoCorrect | boolean | `true` | AutoCorrect the search bar text.
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ export default class Search extends Component {
     clearOnShow: PropTypes.bool,
     clearOnHide: PropTypes.bool,
     focusOnLayout: PropTypes.bool,
+    autoCorrect: PropTypes.bool
   }
 
   static defaultProps = {
@@ -57,6 +58,7 @@ export default class Search extends Component {
     clearOnShow: false,
     clearOnHide: true,
     focusOnLayout: true,
+    autoCorrect: true,
   }
 
   constructor(props) {
@@ -206,6 +208,7 @@ export default class Search extends Component {
                 value={this.state.input}
                 underlineColorAndroid='transparent'
                 returnKeyType='search'
+                autoCorrect={this.props.autoCorrect}
               />
             <TouchableOpacity onPress={hideX || this.state.input === '' ? null : this._clearInput}>
                   <Icon


### PR DESCRIPTION
I was still getting underlines under the search bar text - I even tried setting underlineColorAndroid='rgba(0,0,0,0)' with no results. However, I found that the pesky underline goes away after setting the TextInput prop autoCorrect={false} 