### PR TITLE
Fixed weird RCTShadowView/FlexBasis bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -268,6 +268,7 @@ const styles = StyleSheet.create({
         },
     }),
     flex: 1,
+    flexBasis: 1,
     flexDirection: 'row',
     justifyContent: 'space-around',
     alignItems: 'center',


### PR DESCRIPTION
Whenever the search bar would render, I would be met with this red screen:
![screen shot 2017-02-05 at 3 17 47 pm](https://cloud.githubusercontent.com/assets/7605010/22629601/d6f07308-ebb6-11e6-9d34-458aeb39620a.png)
The app could still be used by just dismissing the screen, but this was annoying.

After consulting [here](http://stackoverflow.com/questions/41004883/react-native-view-was-rendered-with-explicitly-set-width-height-but-with-a-0-fle), I added this change and the issue went away. I cannot perceive any visual changes.