### PR TITLE
Add preventClearIfEmpty prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ keyboardAppearance | string | 'default' | Determines the color of the keyboard.
 fontFamily | string | `System` | The font family to be used.
 fontSize | number | 20 | Sets the font size.
 allDataOnEmptySearch | boolean | `false` | Search results behave as a `.filter`, returning all data when the input is an empty string.
+preventClearIfEmpty | boolean | `true` | Prevents the X-button to trigger its functionality when the text input is empty.
 
 
 

--- a/index.js
+++ b/index.js
@@ -57,7 +57,8 @@ export default class Search extends Component {
     keyboardAppearance: PropTypes.string,
     fontFamily: PropTypes.string,
     allDataOnEmptySearch: PropTypes.bool,
-    editable: PropTypes.bool
+    editable: PropTypes.bool,
+    preventClearIfEmpty: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -90,7 +91,8 @@ export default class Search extends Component {
     allDataOnEmptySearch: false,
     backCloseSize: 28,
     fontSize: 20,
-    editable: true
+    editable: true,
+    preventClearIfEmpty: true,
   };
 
   constructor(props) {
@@ -160,7 +162,11 @@ export default class Search extends Component {
   };
 
   _handleX = () => {
-    const { onX } = this.props;
+    const { onX, preventClearIfEmpty } = this.props;
+    if (preventClearIfEmpty && this.state.input === '') {
+      return;
+    }
+    
     this._clearInput();
     if (onX) onX();
   };
@@ -342,7 +348,7 @@ export default class Search extends Component {
                 accessibilityComponentType="button"
                 accessibilityLabel={closeButtonAccessibilityLabel}
                 onPress={
-                  hideX || this.state.input === '' ? null : this._handleX
+                  hideX ? null : this._handleX
                 }>
                 {closeButton ? (
                   <View style={{ width: backCloseSize, height: backCloseSize }}>


### PR DESCRIPTION
Using this prop (it is true by default) you will be able to let onX trigger even if the text input is empty.

I have the use case for it when i want to close the input field on X-touch (i hide the back-button). And if the input is empty, the onX() won't be triggered.